### PR TITLE
Fix the building of methods: set

### DIFF
--- a/src/session.py
+++ b/src/session.py
@@ -46,7 +46,7 @@ class SocksSession(StreamRequestHandler):
         data = self._src_sock.recv(nmethods)
         methods = set()
         for b in data:
-            methods.add(data[b])
+            methods.add(b)
         if 0 not in methods:
             self.endSession(0)  # End session with unsupported method
         


### PR DESCRIPTION
Fixes an issue seen with some SOCKS clients

The building of the `methods` set is buggy (tries to use the value of each byte of `data` recv'c off the wire to index into `data`). This happens to work OK with the handshake `data` that some clients tend send (e.g. curl) but breaks for other clients (e.g. proxychains, Burp)